### PR TITLE
Make agency react to agent errors

### DIFF
--- a/api/ams/openapi.yaml
+++ b/api/ams/openapi.yaml
@@ -78,7 +78,7 @@ paths:
               schema:
                   $ref: '#/components/schemas/MASs'
     post:
-      description: create a new MAS ressource and sub-ressources
+      description: create a new MAS resource and sub-resources
       requestBody:
         description: configuration of new MAS
         content:
@@ -142,7 +142,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Agents'
     post:
-      description: create new agent ressources
+      description: create new agent resources
       requestBody:
         description: configuration of new agent
         content:

--- a/pkg/agency/agency.go
+++ b/pkg/agency/agency.go
@@ -214,7 +214,7 @@ func (agency *Agency) terminate(gracefulStop chan os.Signal) {
 	agency.logInfo.Println("Terminating agency")
 	agency.mutex.Lock()
 	for i := range agency.localAgents {
-		agency.localAgents[i].Terminate()
+		agency.removeAgent(i)
 	}
 	agency.mutex.Unlock()
 	agency.mqttCollector.close()
@@ -226,10 +226,11 @@ func (agency *Agency) terminate(gracefulStop chan os.Signal) {
 // goroutine and waits until a runtime error occurs in an agent and is sent to the agency's channel errChan
 func (agency *Agency) catchAgentErr() {
 	err := <-agency.errChan
-	agency.logError.Fatal("Caught error: `" + err.Error() + "`. Terminating Agency") // TODO log AgentID
+	agency.logError.Fatal("Caught error: `" + err.Error() + "`.") // TODO log AgentID
+	agency.logInfo.Println("Terminating agency")
 	agency.mutex.Lock()
 	for i := range agency.localAgents {
-		agency.localAgents[i].Terminate()
+		agency.removeAgent(i)
 	}
 	agency.mutex.Unlock()
 	agency.mqttCollector.close()

--- a/pkg/agency/agency.go
+++ b/pkg/agency/agency.go
@@ -100,6 +100,7 @@ func StartAgency(task func(*Agent) error) (err error) {
 		amsClient:      client.NewAMSClient(time.Second*60, time.Second*1, 4),
 		agencyClient:   client.NewAgencyClient(time.Second*60, time.Second*1, 4),
 		logError:       log.New(os.Stderr, "[ERROR] ", log.LstdFlags),
+		errChan:        make(chan error),
 	}
 	err = agency.init()
 	if err != nil {

--- a/pkg/agency/agency.go
+++ b/pkg/agency/agency.go
@@ -208,7 +208,7 @@ func (agency *Agency) init() (err error) {
 	return
 }
 
-// terminate takes care of terminating all parts of the MAP before exiting. It is to be called as a
+// terminate takes care of terminating all parts of the Agency before exiting. It is to be called as a
 // goroutine and waits until an OS signal is inserted into the channel gracefulStop
 func (agency *Agency) terminate(gracefulStop chan os.Signal) {
 	<-gracefulStop
@@ -223,12 +223,11 @@ func (agency *Agency) terminate(gracefulStop chan os.Signal) {
 	os.Exit(0)
 }
 
-// catchAgentErr takes care of terminating all parts of the MAP before exiting. It is to be called as a
+// catchAgentErr takes care of terminating all parts of the Agency before exiting. It is to be called as a
 // goroutine and waits until a runtime error occurs in an agent and is sent to the agency's channel errChan
 func (agency *Agency) catchAgentErr() {
-	err := <-agency.errChan
-	agency.logError.Fatal("Caught error: `" + err.Error() + "`.") // TODO log AgentID
-	agency.logInfo.Println("Terminating agency")
+	<-agency.errChan
+	agency.logError.Println("Caught error. Terminating Agency")
 	agency.mutex.Lock()
 	for i := range agency.localAgents {
 		agency.removeAgent(i)
@@ -236,7 +235,7 @@ func (agency *Agency) catchAgentErr() {
 	agency.mutex.Unlock()
 	agency.mqttCollector.close()
 	time.Sleep(time.Second * 2)
-	os.Exit(0)
+	os.Exit(1)
 }
 
 // startAgents starts all the agents

--- a/pkg/agency/agent.go
+++ b/pkg/agency/agent.go
@@ -121,7 +121,7 @@ func (agent *Agent) startAgent(task func(*Agent) error, e chan error) (err error
 	go func() {
 		err = task(agent)
 		if err != nil {
-			agent.logInfo.Println("Encountered runtime Error: ", err.Error())
+			agent.logError.Println("Agent ", agent.GetAgentID(), " encountered runtime error: ", err.Error())
 			agent.status = status.Error
 			e <- err
 		}

--- a/pkg/agency/agent.go
+++ b/pkg/agency/agent.go
@@ -121,7 +121,7 @@ func (agent *Agent) startAgent(task func(*Agent) error, e chan error) (err error
 	go func() {
 		err = task(agent)
 		if err != nil {
-			agent.logInfo.Println("Encountered Runtime Error: ", err.Error())
+			agent.logInfo.Println("Encountered runtime Error: ", err.Error())
 			agent.status = status.Error
 			e <- err
 		}

--- a/pkg/agency/agent.go
+++ b/pkg/agency/agent.go
@@ -116,9 +116,15 @@ func newAgent(info schemas.AgentInfo, masName string, masCustom string,
 	return
 }
 
-// startAgent starts an agent. It requires an agent task to be executed and the ID of the agent
-func (agent *Agent) startAgent(task func(*Agent) error) (err error) {
-	go task(agent)
+// startAgent starts an agent. It requires an agent task to be executed and the channel to send runtime errors to
+func (agent *Agent) startAgent(task func(*Agent) error, e chan error) (err error) {
+	go func() {
+		err = task(agent)
+		if err != nil {
+			agent.status = status.Error
+			e <- err
+		}
+	}()
 	agent.status = status.Running
 	agent.logInfo.Println("Started agent ", agent.GetAgentID())
 	return

--- a/pkg/agency/agent.go
+++ b/pkg/agency/agent.go
@@ -121,12 +121,13 @@ func (agent *Agent) startAgent(task func(*Agent) error, e chan error) (err error
 	go func() {
 		err = task(agent)
 		if err != nil {
+			agent.logInfo.Println("Encountered Runtime Error: ", err.Error())
 			agent.status = status.Error
 			e <- err
 		}
 	}()
 	agent.status = status.Running
-	agent.logInfo.Println("Started agent ", agent.GetAgentID())
+	agent.logInfo.Println("Started Agent ", agent.GetAgentID())
 	return
 }
 


### PR DESCRIPTION
Closes #15 
When an agent encounters a fatal error, its agency logs that error and gracefully stops.